### PR TITLE
商品詳細機能実施

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,9 +19,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  #   @items = Item.find(params[:id])
-  # end
+  def show
+    @items = Item.find(params[:id])
+  end
 
   # def edit
   #   @items = Item.find(params[:id])

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,37 +127,34 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# <% if @items.size != 0 %> %>
-        <%# <% @items.each do |item| %> %>
+      <% if @items.size != 0 %>
+        <% @items.each do |item| %>
         <li class='list'>
-          <%# <%= link_to item_path(item.id) do %> %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
-            <%# <%= image_tag item.image, class: "item-img"  %> %>
-
+            <%= image_tag item.image, class: "item-img"  %>
             <%# 商品が売れていればsold outを表示しましょう %>
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
             <%# //商品が売れていればsold outを表示しましょう %>
-
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%# <%= item.name %> %>
+              <%= item.name %>
             </h3>
             <div class='item-price'>
-              <%# <span><%= item.price %>円<br> %>
-              <%# <%= item.delivery_fee.name</span> %> %>
+              <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
               </div>
             </div>
           </div>
-          <%# <% end %> %>
+          <% end %>
         </li>
-        <%# <% end %> %>
-      <%# <% else %> %>
+        <% end %>
+      <% else %>
       
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
@@ -182,13 +179,13 @@
         </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
-      <%# <% end %> %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>
 </div>
-<%# <%= link_to(new_item_path, class: 'purchase-btn') do %> %>
+<%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-<%# <% end %> %>
+<% end %>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,10 +3,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%# <%= @items.name %> %>
+      <%= @items.name %>
     </h2>
     <div class='item-img-content'>
-      <%# <%= image_tag @items.image ,class:"item-box-img" %> %>
+      <%= image_tag @items.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -15,53 +15,53 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%# <%= @items.price%> %>
+        <%= @items.price%>
       </span>
       <span class="item-postage">
-        <%# <%= @items.delivery_fee.name %> %>
+        <%= @items.delivery_fee.name %>
       </span>
     </div>
 
-    <%# <% if user_signed_in? && current_user.id == @items.user_id %>
-    <%# <%= link_to '商品の編集', edit_item_path(@items.id), method: :get, class: "item-red-btn" %> %>
-    <%# <p class='or-text'>or</p> %>
-    <%# <%= link_to '削除', item_path(@items.id), method: :delete, class:'item-destroy' %> %>
-    <%# <% end %> %> %>
+    <% if user_signed_in? && current_user.id == @items.user_id %>
+    <%= link_to '商品の編集', edit_item_path(@items.id), method: :get, class: "item-red-btn" %>
+    <p class='or-text'>or</p>
+    <%= link_to '削除', item_path(@items.id), method: :delete, class:'item-destroy' %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%# <% if user_signed_in? && current_user.id != @items.user_id %> %>
+    <% if user_signed_in? && current_user.id != @items.user_id %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# <% end %> %>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <div class="item-explain-box">
-      <%# <span><%= @items.explanation %></span> %>
+      <span><%= @items.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <%# <td class="detail-value"><%= @items.name %></td> %>
+          <td class="detail-value"><%= @items.name%></td> 
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <%# <td class="detail-value"><%= @items.category.name %></td> %>
+          <td class="detail-value"><%= @items.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <%# <td class="detail-value"><%= @items.status.name %></td> %>
+          <td class="detail-value"><%= @items.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <%# <td class="detail-value"><%= @items.delivery_fee.name %></td> %>
+          <td class="detail-value"><%= @items.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <%# <td class="detail-value"><%= @items.prefecture.name %></td> %>
+          <td class="detail-value"><%= @items.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <%# <td class="detail-value"><%= @items.day.name %></td> %>
+          <td class="detail-value"><%= @items.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,10 +26,10 @@
     <%= link_to '商品の編集', edit_item_path(@items.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', item_path(@items.id), method: :delete, class:'item-destroy' %>
-    <% end %>
+    
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if user_signed_in? && current_user.id != @items.user_id %>
+    <% elsif user_signed_in? %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
#What
商品詳細機能を作成いたしました。
#why
同じブランチに複数機能があったため、全てコメントアウトから表示に変えています。
showアクションのビューファイルで一部使用するコメントアウトがあるため、そのコメントのみ残しております。
#商品一覧機能
https://gyazo.com/aefa0d0999c2dc5020d79b9ba73c8926

#ログアウトしたユーザーでも、商品一覧を見ることができる
https://gyazo.com/afed2a892d87d2a6094135263eec14d1

#商品詳細機能(ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること、ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること）
https://gyazo.com/41d6ce7439639838e04869ecf41e5bab

#商品詳細機能(ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること,ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと)
https://gyazo.com/6084c451db02db0dad936edee039b1cd